### PR TITLE
Fix autorun all-files check

### DIFF
--- a/calls/callbacks/main/autorunCallback.m
+++ b/calls/callbacks/main/autorunCallback.m
@@ -121,6 +121,10 @@ setFigOnTop % Sets the waitbar so that it is always in front
 
 for i = 1:length(files)
     file = files(i);
+    % Ensure callbacks expecting the selected file operate on the
+    % current item by updating the file listbox
+    set(mainhandles.FilesListbox,'Value',file)
+    mainhandles = guidata(mainhandles.figure1);
     
     % If spot-profile, ignore it
     if mainhandles.data(file).spot

--- a/calls/callbacks/main/autorunCallback.m
+++ b/calls/callbacks/main/autorunCallback.m
@@ -48,7 +48,13 @@ set(mainhandles.mboard, 'String',textstr)
 mainhandles = myguidebox(mainhandles, 'Auto-run analysis', textstr, 'autorun',1,'http://isms.au.dk/getstarted/quick4/');
 
 % Determine how many files to run analysis
-if mainhandles.settings.autorun.AllFiles==1
+allFilesSetting = mainhandles.settings.autorun.AllFiles;
+if ischar(allFilesSetting)
+    allFilesSetting = strcmpi(allFilesSetting,'all files');
+elseif islogical(allFilesSetting)
+    allFilesSetting = allFilesSetting~=0;
+end
+if allFilesSetting==1
     files = 1:length(mainhandles.data);
     
     % Check if some data files have already been analysed

--- a/calls/callbacks/main/autorunCallback.m
+++ b/calls/callbacks/main/autorunCallback.m
@@ -50,9 +50,14 @@ mainhandles = myguidebox(mainhandles, 'Auto-run analysis', textstr, 'autorun',1,
 % Determine how many files to run analysis
 allFilesSetting = mainhandles.settings.autorun.AllFiles;
 if ischar(allFilesSetting)
-    allFilesSetting = strcmpi(allFilesSetting,'all files');
+    numericVal = str2double(allFilesSetting);
+    if ~isnan(numericVal)
+        allFilesSetting = numericVal;
+    else
+        allFilesSetting = strcmpi(strtrim(allFilesSetting),'all files');
+    end
 elseif islogical(allFilesSetting)
-    allFilesSetting = allFilesSetting~=0;
+    allFilesSetting = double(allFilesSetting~=0);
 end
 if allFilesSetting==1
     files = 1:length(mainhandles.data);


### PR DESCRIPTION
## Summary
- make autorun handle non-numeric `AllFiles` settings to avoid only the selected file being processed

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_688b7fb9d0108324b20f6c94e0f4710b