### PR TITLE
Fix correction factor label placement

### DIFF
--- a/calls/callbacks/FRETpairwindow/FRETpairwindowResizeFcn.m
+++ b/calls/callbacks/FRETpairwindow/FRETpairwindowResizeFcn.m
@@ -118,7 +118,7 @@ setpixelposition(fpHandles.DDtraceAxes,[axX vpos axW axH])
 if editW>=1
     vpos = bottomspace;%axspaceB-vergap-checkH;
     setpixelposition(fpHandles.molspecCheckbox, [imX vpos imW+rightspace checkH])
-    
+
     vpos = axspaceB;
     setpixelposition(fpHandles.GammaTextbox, [imX vpos textW2 textheight])
     setpixelposition(fpHandles.GammaEditbox, [imX+textW2+horspace vpos editW editheight])
@@ -132,6 +132,10 @@ if editW>=1
     vpos = vpos+editheight+verspace;
     setpixelposition(fpHandles.DleakTextbox, [imX vpos textW2 textheight])
     setpixelposition(fpHandles.DleakEditbox, [imX+textW2+horspace vpos editW editheight])
+
+    % Place section label above the correction factor values
+    vpos = vpos+editheight+verspace;
+    setpixelposition(fpHandles.CorrectionFactorsTextbox, [imX-rightspace vpos imW+2*rightspace textheight])
 end
 
 % Pair coordinates
@@ -145,8 +149,6 @@ vpos = vpos-2*textheight-verspace;
 setpixelposition(fpHandles.PairCoordinatesTextbox, [imX-4 vpos imW+8 textheight])
 vpos = vpos+textheight+verspace;
 setpixelposition(fpHandles.paircoordinates, [imX-4 vpos imW+8 textheight])
-vpos = vpos+textheight+verspace;
-setpixelposition(fpHandles.CorrectionFactorsTextbox, [imX-rightspace vpos imW+2*rightspace textheight])
 
 % Images
 vpos = axspaceB+2*axH+2*axspaceV;


### PR DESCRIPTION
## Summary
- Position "Correction factors" label above correction factor fields
- Remove stray placement of correction label near pair coordinates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ceae9c9f88324b66789b02f7a4501