### PR TITLE
Safeguard data template saving

### DIFF
--- a/calls/callbacks/main/loadDataCallback.m
+++ b/calls/callbacks/main/loadDataCallback.m
@@ -190,7 +190,7 @@ end
 %% Save default data structure format to file
 % (for software version compatibility)
 
-try 
+if ~isempty(mainhandles.data)
     % Delete file specific data
     dataTemplate = mainhandles.data(end);
     dataTemplate.back = [];
@@ -219,14 +219,8 @@ try
     dataTemplate.donors(:) = [];
     dataTemplate.rawmovieLength = [];
     dataTemplate.time = [];
-end
-
-try
-    % Save file with settings structure
     dataTemplateFile = fullfile(mainhandles.settingsdir,'data.template');
     save(dataTemplateFile,'dataTemplate');
-catch err
-    fprintf('Error when trying to save default data template:\n\n %s',err.message)
 end
 
 %% Update GUI and finish


### PR DESCRIPTION
## Summary
- Only save default data template when `mainhandles.data` is available
- Consolidate field resets and save operation into a single conditional block

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8373550c08324993f3728159ce365